### PR TITLE
Fix description of emailDomain function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ public static function charWrap(
 
 ### [emailDomain](#emailDomain)
 
-Wraps a string at a given number of characters regardless of words.
+Extracts the domain part of an email address, including subdomains.
 
 ```php
-public static function EmailDomain(
+public static function emailDomain(
     $string
 )
 ```


### PR DESCRIPTION
Hey Matt, cool package! Was just reading through the readme and noticed the `emailDomain` description had the same one for `charWrap`.